### PR TITLE
Check if npm is already exists before installing

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,13 +37,18 @@
 - name: Create statsd init.d script
   template: src="etc/init/statsd.{{ ansible_os_family }}.j2" dest=/etc/init.d/statsd owner=root group=root mode=0755
 
+- name: Check if npm is installed
+  command: 'npm --version > /dev/null 2>&1'
+  register: npm_check
+  ignore_errors: True
+
 - name: Install npm
   yum: name=npm
-  when: librato_email is defined and ansible_pkg_mgr == 'yum'
+  when: librato_email is defined and ansible_pkg_mgr == 'yum' and npm_check|failed
 
 - name: Install npm
   apt: name=npm
-  when: librato_email is defined and ansible_pkg_mgr == 'apt'
+  when: librato_email is defined and ansible_pkg_mgr == 'apt' and npm_check|failed
 
 - name: Install librato plugin
   command: npm install statsd-librato-backend chdir=/opt/statsd


### PR DESCRIPTION
Installing npm from official repository may cause conflicts if npm is already installed from other places (chris-lea's PPA in my case).

Namely, in my case this role tries to install package 'npm' but this binary is already installed with nodejs package. I think adding condition which package to install is too complex so I just added condition if npm binary is callable.
